### PR TITLE
Bugfix

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -10,6 +10,7 @@ class LinksController < ApplicationController
   def create
     @link = Link.new(link_params)
     @link.user_id = session[:user_id].to_i
+    @top10 = top10_links
     if !@link.save
       flash[:error] = @link.errors.full_messages
       @links = current_user_links

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  root to: "links#index"
+  root :to => redirect(path: '/links')
 
   get 'signin' => 'sessions#new'
   post 'signin' => 'sessions#create'
@@ -8,7 +8,6 @@ Rails.application.routes.draw do
 
   get 'signup' => 'users#new'
   post 'signup' => 'users#create'
-
 
   resources :links, only: [:index, :create, :update]
   put 'updatelink/:id' => 'links#updatelink'

--- a/spec/features/a_user_can_add_a_link_spec.rb
+++ b/spec/features/a_user_can_add_a_link_spec.rb
@@ -52,6 +52,7 @@ describe 'User adding a new link', js:true do
       test_title = 'Test title'
       test_invalid_url = 'invalidURL'
       test_valid_url = 'https://urlockbox-laszlo.herokuapp.com'
+
       fill_in 'link[title]', with: test_title
       fill_in 'link[url]', with: test_invalid_url
       click_on 'Save Link'
@@ -60,7 +61,6 @@ describe 'User adding a new link', js:true do
       fill_in 'link[url]', with: test_valid_url
       click_on 'Save Link'
 
-      expect(page).to have_current_path(links_path)
       expect(page).to have_current_path(links_path)
       expect(page).to have_content(test_title)
       expect(page).to have_content(test_valid_url)


### PR DESCRIPTION
- Fix bug of links_path reloading when new link is submitted  
- Fix `root` reroute to `links_path`

Note: two tests fail when `rspec` runs, but they pass then individual `spec` files are executed. As well as the relevant functionality has been confirmed through browser testing as well.